### PR TITLE
fix: don't spawn sidecar with detached

### DIFF
--- a/extensions/codestory/src/utilities/setupSidecarBinary.ts
+++ b/extensions/codestory/src/utilities/setupSidecarBinary.ts
@@ -339,14 +339,10 @@ async function runSideCarBinary(sidecarDestination: string, serverUrl: string) {
 			setTimeout(spawnChild, delay);
 		};
 		try {
-			// NodeJS bug requires not using detached on Windows, otherwise windowsHide is ineffective
-			// Otherwise, detach is preferable
 			const windowsSettings = {
 				windowsHide: true,
 			};
 			const macLinuxSettings = {
-				detached: true,
-				stdio: 'ignore',
 			};
 			const settings: any = os.platform() === 'win32' ? windowsSettings : macLinuxSettings;
 


### PR DESCRIPTION
re: the way the sidecar process keeps running in the background after exit, it looks to be related to

```
const macLinuxSettings = {
    detached: true,
    stdio: 'ignore',
};
```

https://nodejs.org/api/child_process.html#optionsdetached

"When using the detached option to start a long-running process, the process will not stay running in the background after the parent exits unless it is provided with a stdio configuration that is not connected to the parent. If the parent's stdio is inherited, the child will remain attached to the controlling terminal."

So I think options to ensure the sidecar process gets terminated would include:

1) removing the "detached" option
2) removing the "stdio" option
3) remove both

Seems like simplest would be to remove both options, which is what I've done here.

I've not currently got things set up to test this locally, so I may be mistaken. Maybe at some point I'll try to get the dev container to work...