### PR TITLE
Add extension deactivate function to terminate webserver on exit

### DIFF
--- a/extensions/codestory/src/extension.ts
+++ b/extensions/codestory/src/extension.ts
@@ -19,7 +19,7 @@ import { copySettings } from './utilities/copySettings';
 import { getRelevantFiles, shouldTrackFile } from './utilities/openTabs';
 import { checkReadonlyFSMode } from './utilities/readonlyFS';
 import { reportIndexingPercentage } from './utilities/reportIndexingUpdate';
-import { startSidecarBinary } from './utilities/setupSidecarBinary';
+import { startSidecarBinary, killSidecarProcess } from './utilities/setupSidecarBinary';
 import { readCustomSystemInstruction } from './utilities/systemInstruction';
 import { getUniqueId } from './utilities/uniqueId';
 import { ProjectContext } from './utilities/workspaceContext';
@@ -277,4 +277,8 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	// shouldn't all listeners have this?
 	context.subscriptions.push(diagnosticsListener);
+}
+
+export async function deactivate() {
+	await killSidecarProcess();
 }


### PR DESCRIPTION
This exports a new `deactivate` function from the Codestory extension, alongside the existing `activate` function, which VS Code will call on all extensions when closing down.

This function terminates the webserver. To make this work I've promisified the existing process termination code, because callbacks won't work if an application is about to exit.

For context, I previously attempted to fix the issue of the sidecar not exiting on IDE exit by deleting the `detached` and `stdio` options passed to `spawn` in a previous PR but that didn't work, and I didn't have Aide set up to compile locally at the time to check.

I thought removing `detached` and `stdio` would work as I tested it in a tiny node app, and the spawned process closes at exit as intended (https://github.com/jamesjrg/node-playground/blob/main/node_spawn_process/src/app.ts). However if I do the same in a tiny Electron app then the process keeps living for some reason (https://github.com/jamesjrg/node-playground/blob/main/my-electron-app/main.mjs).

This seems contrary to the google results I can find that say child processes started by Electron should end when the parent ends. See e.g. https://www.matthewslipper.com/2019/09/22/everything-you-wanted-electron-child-process.html "Child Process Lifetimes". Although that article is about forking another node process rather than using spawn, so maybe that's the difference.