### PR TITLE
Revert deactivate function

### DIFF
--- a/extensions/codestory/src/extension.ts
+++ b/extensions/codestory/src/extension.ts
@@ -19,7 +19,7 @@ import { copySettings } from './utilities/copySettings';
 import { getRelevantFiles, shouldTrackFile } from './utilities/openTabs';
 import { checkReadonlyFSMode } from './utilities/readonlyFS';
 import { reportIndexingPercentage } from './utilities/reportIndexingUpdate';
-import { startSidecarBinary, killSidecarProcess } from './utilities/setupSidecarBinary';
+import { startSidecarBinary } from './utilities/setupSidecarBinary';
 import { readCustomSystemInstruction } from './utilities/systemInstruction';
 import { getUniqueId } from './utilities/uniqueId';
 import { ProjectContext } from './utilities/workspaceContext';
@@ -277,8 +277,4 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	// shouldn't all listeners have this?
 	context.subscriptions.push(diagnosticsListener);
-}
-
-export async function deactivate() {
-	await killSidecarProcess();
 }

--- a/extensions/codestory/src/utilities/setupSidecarBinary.ts
+++ b/extensions/codestory/src/utilities/setupSidecarBinary.ts
@@ -98,46 +98,53 @@ async function checkServerRunning(serverUrl: string): Promise<boolean> {
 	}
 }
 
-async function killProcessOnPort(port: number): Promise<void> {
+function killProcessOnPort(port: number) {
 	if (os.platform() === 'win32') {
 		// Find the process ID using netstat (this command is for Windows)
-		const { stdout, stderr } = await promisify(exec)(`netstat -ano | findstr :${port}`);
-		if (stderr) {
-			console.error(`exec error: ${stderr}`);
-			return;
-		}
-		const pid = stdout.split(/\s+/).slice(-2, -1)[0];
-
-		if (pid) {
-			// Kill the process
-			const { stderr } = await promisify(exec)(`taskkill /PID ${pid} /F`);
-			if (stderr) {
-				console.error(`Error killing process: ${stderr}`);
+		exec(`netstat -ano | findstr :${port}`, (error, stdout) => {
+			if (error) {
+				console.error(`exec error: ${error}`);
 				return;
 			}
-		} else {
-			// console.log(`No process running on port ${port}`);
-		}
+
+			const pid = stdout.split(/\s+/).slice(-2, -1)[0];
+
+			if (pid) {
+				// Kill the process
+				exec(`taskkill /PID ${pid} /F`, (killError) => {
+					if (killError) {
+						console.error(`Error killing process: ${killError}`);
+						return;
+					}
+					// console.log(`Killed process with PID: ${pid}`);
+				});
+			} else {
+				// console.log(`No process running on port ${port}`);
+			}
+		});
 	} else {
 		// Find the process ID using lsof (this command is for macOS/Linux)
-		const { stdout, stderr } = await promisify(exec)(`lsof -i :${port} | grep LISTEN | awk '{print $2}'`);
-
-		if (stderr) {
-			console.error(`exec error: ${stderr}`);
-		}
-
-		const pid = stdout.trim();
-
-		if (pid) {
-			// Kill the process
-			const { stderr } = await promisify(execFile)('kill', ['-2', `${pid}`]);
-			if (stderr) {
-				console.error(`Error killing process: ${stderr}`);
+		exec(`lsof -i :${port} | grep LISTEN | awk '{print $2}'`, (error, stdout) => {
+			if (error) {
+				console.error(`exec error: ${error}`);
 				return;
 			}
-		} else {
-			// console.log(`No process running on port ${port}`);
-		}
+
+			const pid = stdout.trim();
+
+			if (pid) {
+				// Kill the process
+				execFile('kill', ['-2', `${pid}`], (killError) => {
+					if (killError) {
+						console.error(`Error killing process: ${killError}`);
+						return;
+					}
+					// console.log(`Killed process with PID: ${pid}`);
+				});
+			} else {
+				// console.log(`No process running on port ${port}`);
+			}
+		});
 	}
 }
 
@@ -146,7 +153,7 @@ async function checkOrKillRunningServer(serverUrl: string): Promise<boolean> {
 	if (serverRunning) {
 		// console.log('Killing previous sidecar server');
 		try {
-			await killSidecarProcess();
+			killProcessOnPort(42424);
 		} catch (e: any) {
 			if (!e.message.includes('Process doesn\'t exist')) {
 				// console.log('Failed to kill old server:', e);
@@ -277,10 +284,6 @@ export async function startSidecarBinary(
 	// Get name of the corresponding executable for platform
 	await runSideCarBinary(sidecarDestination, serverUrl);
 	return 'http://127.0.0.1:42424';
-}
-
-export function killSidecarProcess(): Promise<void> {
-	return killProcessOnPort(42424);
 }
 
 async function runSideCarBinary(sidecarDestination: string, serverUrl: string) {


### PR DESCRIPTION
Lots of people are having issues with the sidecar process not being available. I wonder if my previous PR (which killed the sidecar whenever in the extension deactivate() method) may have made things worse, so it's seems safer to revert it.

[UPDATE a month later: using deactivate was the correct thing to do after all, but there were other issues with process management...]