### PR TITLE
Change sidecar binary process logic

### DIFF
--- a/extensions/codestory/src/extension.ts
+++ b/extensions/codestory/src/extension.ts
@@ -19,7 +19,7 @@ import { copySettings } from './utilities/copySettings';
 import { getRelevantFiles, shouldTrackFile } from './utilities/openTabs';
 import { checkReadonlyFSMode } from './utilities/readonlyFS';
 import { reportIndexingPercentage } from './utilities/reportIndexingUpdate';
-import { startSidecarBinary } from './utilities/setupSidecarBinary';
+import { startSidecarBinary, killSidecarProcess } from './utilities/setupSidecarBinary';
 import { readCustomSystemInstruction } from './utilities/systemInstruction';
 import { getUniqueId } from './utilities/uniqueId';
 import { ProjectContext } from './utilities/workspaceContext';
@@ -284,4 +284,8 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	// shouldn't all listeners have this?
 	context.subscriptions.push(diagnosticsListener);
+}
+
+export async function deactivate() {
+	await killSidecarProcess();
 }

--- a/extensions/codestory/src/extension.ts
+++ b/extensions/codestory/src/extension.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import * as os from 'os';
 import * as vscode from 'vscode';
+import * as path from 'path';
 
 import { createInlineCompletionItemProvider } from './completions/create-inline-completion-item-provider';
 import { AideAgentSessionProvider } from './completions/providers/aideAgentProvider';
@@ -26,6 +27,7 @@ import { ProjectContext } from './utilities/workspaceContext';
 import { CSEventHandler } from './csEvents/csEventHandler';
 import { RecentEditsRetriever } from './server/editedFiles';
 import { getRipGrepPath } from './utilities/ripGrep';
+import { sidecarUseSelfRun } from './utilities/sidecarUrl';
 // import { GENERATE_PLAN } from './completions/providers/generatePlan';
 // import { OPEN_FILES_VARIABLE } from './completions/providers/openFiles';
 
@@ -110,7 +112,15 @@ export async function activate(context: vscode.ExtensionContext) {
 	// Get model selection configuration
 	const modelConfiguration = await vscode.modelSelection.getConfiguration();
 	// Setup the sidecar client here
-	const sidecarUrl = await startSidecarBinary(context.globalStorageUri.fsPath, vscode.env.appRoot);
+	const sideCarBinDir = vscode.Uri.joinPath(
+		vscode.extensions.getExtension('codestory-ghost.codestoryai')?.extensionUri ?? vscode.Uri.parse(''),
+		'sidecar_bin', 'target', 'release').toString();
+
+	const sidecarBinPath = (os.platform() === 'win32')
+		? path.join(sideCarBinDir, 'webserver.exe')
+		: path.join(sideCarBinDir, 'webserver');
+
+	const sidecarUrl = await startSidecarBinary(sidecarBinPath);
 	// allow-any-unicode-next-line
 	// window.showInformationMessage(`Sidecar binary 🦀 started at ${sidecarUrl}`);
 	const sidecarClient = new SideCarClient(sidecarUrl, modelConfiguration);
@@ -287,5 +297,7 @@ export async function activate(context: vscode.ExtensionContext) {
 }
 
 export async function deactivate() {
-	await killSidecarProcess();
+	if (!sidecarUseSelfRun()) {
+		await killSidecarProcess();
+	}
 }

--- a/extensions/codestory/src/utilities/setupSidecarBinary.ts
+++ b/extensions/codestory/src/utilities/setupSidecarBinary.ts
@@ -98,53 +98,46 @@ async function checkServerRunning(serverUrl: string): Promise<boolean> {
 	}
 }
 
-function killProcessOnPort(port: number) {
+async function killProcessOnPort(port: number): Promise<void> {
 	if (os.platform() === 'win32') {
 		// Find the process ID using netstat (this command is for Windows)
-		exec(`netstat -ano | findstr :${port}`, (error, stdout) => {
-			if (error) {
-				console.error(`exec error: ${error}`);
+		const { stdout, stderr } = await promisify(exec)(`netstat -ano | findstr :${port}`);
+		if (stderr) {
+			console.error(`exec error: ${stderr}`);
+			return;
+		}
+		const pid = stdout.split(/\s+/).slice(-2, -1)[0];
+
+		if (pid) {
+			// Kill the process
+			const { stderr } = await promisify(exec)(`taskkill /PID ${pid} /F`);
+			if (stderr) {
+				console.error(`Error killing process: ${stderr}`);
 				return;
 			}
-
-			const pid = stdout.split(/\s+/).slice(-2, -1)[0];
-
-			if (pid) {
-				// Kill the process
-				exec(`taskkill /PID ${pid} /F`, (killError) => {
-					if (killError) {
-						console.error(`Error killing process: ${killError}`);
-						return;
-					}
-					// console.log(`Killed process with PID: ${pid}`);
-				});
-			} else {
-				// console.log(`No process running on port ${port}`);
-			}
-		});
+		} else {
+			// console.log(`No process running on port ${port}`);
+		}
 	} else {
 		// Find the process ID using lsof (this command is for macOS/Linux)
-		exec(`lsof -i :${port} | grep LISTEN | awk '{print $2}'`, (error, stdout) => {
-			if (error) {
-				console.error(`exec error: ${error}`);
+		const { stdout, stderr } = await promisify(exec)(`lsof -i :${port} | grep LISTEN | awk '{print $2}'`);
+
+		if (stderr) {
+			console.error(`exec error: ${stderr}`);
+		}
+
+		const pid = stdout.trim();
+
+		if (pid) {
+			// Kill the process
+			const { stderr } = await promisify(execFile)('kill', ['-2', `${pid}`]);
+			if (stderr) {
+				console.error(`Error killing process: ${stderr}`);
 				return;
 			}
-
-			const pid = stdout.trim();
-
-			if (pid) {
-				// Kill the process
-				execFile('kill', ['-2', `${pid}`], (killError) => {
-					if (killError) {
-						console.error(`Error killing process: ${killError}`);
-						return;
-					}
-					// console.log(`Killed process with PID: ${pid}`);
-				});
-			} else {
-				// console.log(`No process running on port ${port}`);
-			}
-		});
+		} else {
+			// console.log(`No process running on port ${port}`);
+		}
 	}
 }
 
@@ -153,7 +146,7 @@ async function checkOrKillRunningServer(serverUrl: string): Promise<boolean> {
 	if (serverRunning) {
 		// console.log('Killing previous sidecar server');
 		try {
-			killProcessOnPort(42424);
+			await killSidecarProcess();
 		} catch (e: any) {
 			if (!e.message.includes('Process doesn\'t exist')) {
 				// console.log('Failed to kill old server:', e);
@@ -291,6 +284,10 @@ export async function startSidecarBinary(
 	// Get name of the corresponding executable for platform
 	await runSideCarBinary(sidecarDestination, serverUrl);
 	return 'http://127.0.0.1:42424';
+}
+
+export function killSidecarProcess(): Promise<void> {
+	return killProcessOnPort(42424);
 }
 
 async function runSideCarBinary(sidecarDestination: string, serverUrl: string) {

--- a/extensions/codestory/src/utilities/setupSidecarBinary.ts
+++ b/extensions/codestory/src/utilities/setupSidecarBinary.ts
@@ -3,64 +3,18 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { window, ProgressLocation } from 'vscode';
+import { window } from 'vscode';
 import { promisify } from 'util';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
-import { spawn, spawnSync, exec, execFile } from 'child_process';
-import { downloadFromGCPBucket, downloadUsingURL } from './gcpBucket';
+import { spawn, exec, execFile } from 'child_process';
 import { sidecarUseSelfRun } from './sidecarUrl';
 
-
-// Here I want to ask a question about what value does the extracDir take
-// it should be pretty easy to do that
-function unzipSidecarZipFolder(source: string, extractDir: string) {
-	if (source.endsWith('.zip')) {
-		if (process.platform === 'win32') {
-			spawnSync('powershell.exe', [
-				'-NoProfile',
-				'-ExecutionPolicy', 'Bypass',
-				'-NonInteractive',
-				'-NoLogo',
-				'-Command',
-				`Microsoft.PowerShell.Archive\\Expand-Archive -Path "${source}" -DestinationPath "${extractDir}"`
-			]);
-		} else {
-			spawnSync('unzip', ['-o', source, '-d', `${extractDir}`]);
-		}
-	} else {
-		// tar does not create extractDir by default
-		if (!fs.existsSync(extractDir)) {
-			fs.mkdirSync(extractDir);
-		}
-		spawnSync('tar', ['-xzf', source, '-C', extractDir, '--strip-components', '1']);
-	}
-}
 
 // We are going to use a static port right now and nothing else
 export function getSidecarBinaryURL() {
 	return 'http://127.0.0.1:42424';
-}
-
-// We are hardcoding the version of the sidecar binary here, so we can figure out
-// if the version we are looking at is okay, or we need to download a new binary
-// for now, lets keep it as it is and figure out a way to update the hash on
-// important updates
-export const SIDECAR_VERSION = '6e8aaed22c2c4a3331ccea298df96dc5fc1bb5dddd1e6f975f0b5c516cdff28b';
-
-async function checkCorrectVersionRunning(url: string): Promise<boolean> {
-	try {
-		// console.log('Version check starting');
-		const response = await fetch(`${url}/api/version`);
-		// console.log('Version check done' + response);
-		const version = await response.json();
-		// console.log('version content');
-		// console.log(version);
-		return version.version_hash === SIDECAR_VERSION;
-	} catch (e) {
-		return false;
-	}
 }
 
 export async function runCommand(cmd: string): Promise<[string, string | undefined]> {
@@ -79,23 +33,6 @@ export async function runCommand(cmd: string): Promise<[string, string | undefin
 
 	const stderrOrUndefined = stderr === '' ? undefined : stderr;
 	return [stdout, stderrOrUndefined];
-}
-
-async function checkServerRunning(serverUrl: string): Promise<boolean> {
-	try {
-		// console.log('Health check starting');
-		const response = await fetch(`${serverUrl}/api/health`);
-		if (response.status === 200) {
-			// console.log('Sidecar server already running');
-			// console.log('Health check done');
-			return true;
-		} else {
-			// console.log('Health check done');
-			return false;
-		}
-	} catch (e) {
-		return false;
-	}
 }
 
 async function killProcessOnPort(port: number): Promise<void> {
@@ -141,177 +78,60 @@ async function killProcessOnPort(port: number): Promise<void> {
 	}
 }
 
-async function checkOrKillRunningServer(serverUrl: string): Promise<boolean> {
-	const serverRunning = await checkServerRunning(serverUrl);
-	if (serverRunning) {
-		// console.log('Killing previous sidecar server');
-		try {
-			await killSidecarProcess();
-		} catch (e: any) {
-			if (!e.message.includes('Process doesn\'t exist')) {
-				// console.log('Failed to kill old server:', e);
-			}
-		}
-	}
-	return false;
-}
-
 export async function startSidecarBinaryWithLocal(
-	installLocation: string,
+	sidecarBinPath: string,
 ): Promise<boolean> {
-	// Fixing the variable name here from sserverUrl -> serverUrl
-	// should be automatig, or can we really do it with lsp
 	const serverUrl = getSidecarBinaryURL();
-	const shouldUseSelfRun = sidecarUseSelfRun();
-	if (shouldUseSelfRun) {
-		return true;
-	}
-	// check here if the binary is downloaded locally and if thats the case
-	// try to run it from there
-	const sidecarBinPath = path.join(installLocation, 'extensions', 'codestory', 'sidecar_bin');
-	// console.log('startSidecarBinaryWithLocation', sidecarBinPath);
-	if (fs.existsSync(sidecarBinPath)) {
-		const sidecarBinPathExists = fs.existsSync(path.join(sidecarBinPath, 'sidecar'));
-		if (sidecarBinPathExists) {
-			try {
-				// console.log('Starting sidecar binary locally', sidecarBinPath, serverUrl);
-				const sidecarValue = await runSideCarBinary(sidecarBinPath, serverUrl);
-				// console.log('Sidecar binary exists locally, running it', sidecarValue);
-				return sidecarValue;
-			} catch (e) {
-				return false;
-				// console.log('Failed to run sidecar binary locally', e);
-			}
-		}
-	}
-
-	return false;
+	return await runSideCarBinary(sidecarBinPath, serverUrl);
 }
-
 
 export async function startSidecarBinary(
-	extensionBasePath: string,
-	installLocation: string,
+	sidecarBinPath: string,
 ): Promise<string> {
-	const sidecarServerUrl = 'http://127.0.0.1:42424';
-	// Check if we are running the correct version, or else we download a new version
-	if (!await checkCorrectVersionRunning(sidecarServerUrl)) {
-		console.log('correct version of sidecar is not running, killing the server');
-		await checkOrKillRunningServer(sidecarServerUrl);
-	}
-	// if the correct version is already running, then just return it
-	if (await checkCorrectVersionRunning(sidecarServerUrl)) {
+	const sidecarServerUrl = getSidecarBinaryURL();
+
+	const shouldUseSelfRun = sidecarUseSelfRun();
+	if (shouldUseSelfRun) {
 		return sidecarServerUrl;
 	}
-	console.log('starting sidecar binary locally');
+
+	// In theory any existing process should already have been killed when
+	// the extension was last deactivated (either by opening a folder or exiting the IDE),
+	// so there shouldn't be any server running.
+	// But to be on the safe side,
+	// check and kill any current process just in case an old version has been left running somehow
+	await killSidecarProcess();
+
+	console.log('starting sidecar binary');
 	// We want to check where the sidecar binary is stored
 	// extension_path: /Users/skcd/.vscode-oss-dev/User/globalStorage/codestory-ghost.codestoryai/sidecar_bin
 	// installation location: /Users/skcd/Downloads/Aide.app/Contents/Resources/app/extensions/codestory/sidecar_bin
 	// we have to figure out how to copy them together
 	// console.log('starting sidecar binary');
-	// console.log('installLocation', installLocation);
-	const selfStart = await startSidecarBinaryWithLocal(installLocation);
-	if (selfStart) {
-		return 'http://127.0.0.1:42424';
-	}
-	// Check vscode settings
-	const serverUrl = getSidecarBinaryURL();
-	const shouldUseSelfRun = sidecarUseSelfRun();
-	if (shouldUseSelfRun) {
-		return serverUrl;
-	}
+	await startSidecarBinaryWithLocal(sidecarBinPath);
 
-	// Check if we are running the correct version, or else we download a new version
-	if (await checkCorrectVersionRunning(serverUrl)) {
-		// console.log('Correct version of Sidecar binary is running');
-		return 'http://127.0.0.1:42424';
-	}
-
-	// First let's kill the running version
-	// console.log('Killing running Sidecar binary');
-	await checkOrKillRunningServer(serverUrl);
-
-	// console.log('Starting Sidecar binary right now');
-
-	// Download the server executable
-	const bucket = 'sidecar-bin';
-	const fileName =
-		os.platform() === 'win32'
-			? 'windows/sidecar.zip'
-			: os.platform() === 'darwin'
-				? 'mac/sidecar.zip'
-				: 'linux/sidecar.zip';
-
-	const zipDestination = path.join(
-		extensionBasePath,
-		'sidecar_zip.zip',
-	);
-	const sidecarDestination = path.join(
-		extensionBasePath,
-		'sidecar_bin',
-	);
-
-	// First, check if the server is already downloaded
-	// console.log('Downloading the sidecar binary...');
-	await window.withProgress(
-		{
-			location: ProgressLocation.SourceControl,
-			// allow-any-unicode-next-line
-			title: 'Downloading the sidecar binary 🦀',
-			cancellable: false,
-		},
-		async () => {
-			try {
-				await downloadFromGCPBucket(bucket, fileName, zipDestination);
-			} catch (e) {
-				// console.log('Failed to download from GCP bucket, trying using URL: ', e);
-				await downloadUsingURL(bucket, fileName, zipDestination);
-			}
-		}
-	);
-
-	// console.log(`Downloaded sidecar zip at ${zipDestination}`);
-	// Now we need to unzip the folder in the location and also run a few commands
-	// for the dylib files and the binary
-	// -o is important here because we want to override the downloaded binary
-	// if it has been already downloaded
-	// console.log(zipDestination);
-	// console.log(sidecarDestination);
-	// hopefully this works as we want it to
-	unzipSidecarZipFolder(zipDestination, sidecarDestination);
-	// now delete the zip file
-	fs.unlinkSync(zipDestination);
-	// Get name of the corresponding executable for platform
-	await runSideCarBinary(sidecarDestination, serverUrl);
-	return 'http://127.0.0.1:42424';
+	return sidecarServerUrl;
 }
 
 export function killSidecarProcess(): Promise<void> {
 	return killProcessOnPort(42424);
 }
 
-async function runSideCarBinary(sidecarDestination: string, serverUrl: string) {
-	let webserverPath = null;
-	if (os.platform() === 'win32') {
-		webserverPath = path.join(sidecarDestination, 'target', 'release', 'webserver.exe');
-	} else {
-		webserverPath = path.join(sidecarDestination, 'target', 'release', 'webserver');
-	}
-
+async function runSideCarBinary(sidecarBinPath: string, serverUrl: string) {
 	if (os.platform() === 'darwin' || os.platform() === 'linux') {
 		// Now we want to change the permissions for the following files:
 		// target/release/webserver
-		fs.chmodSync(webserverPath, 0o7_5_5);
+		fs.chmodSync(sidecarBinPath, 0o7_5_5);
 	}
 
 	if (os.platform() === 'darwin') {
 		// We need to run this command on the darwin platform
-		await runCommand(`xattr -dr com.apple.quarantine ${webserverPath}`);
+		await runCommand(`xattr -dr com.apple.quarantine ${sidecarBinPath}`);
 	}
 
 
 	// Validate that the file exists
-	if (!fs.existsSync(webserverPath)) {
+	if (!fs.existsSync(sidecarBinPath)) {
 		const errText = `- Failed to install Sidecar binary.`;
 		window.showErrorMessage(errText);
 		throw new Error(errText);
@@ -338,15 +158,7 @@ async function runSideCarBinary(sidecarDestination: string, serverUrl: string) {
 			};
 			const settings: any = os.platform() === 'win32' ? windowsSettings : macLinuxSettings;
 
-			let sidecarBinary = '';
-			if (os.platform() === 'win32') {
-				sidecarBinary = path.join(sidecarDestination, 'target', 'release', 'webserver.exe');
-			} else {
-				sidecarBinary = path.join(sidecarDestination, 'target', 'release', 'webserver');
-			}
-			// console.log('what are the args');
-			// console.log(args, sidecarBinary);
-			const child = spawn(sidecarBinary, settings);
+			const child = spawn(sidecarBinPath, settings);
 
 			// Either unref to avoid zombie process, or listen to events because you can
 			if (os.platform() === 'win32') {


### PR DESCRIPTION
This PR has 3 parts:

1. Add extension deactivate function to terminate webserver on exit (note this is a change that was previously applied then reverted). This ensures the sidecar isn't left running in the background using up resources after exiting the IDE, which might upset users.

2. Remove all logic related to version checking the sidecar and downloading binary from GCP bucket if the version doesn't match. Instead, always terminate any running sidecar binary and restart the version packaged with the IDE any time the extension is activated.

3. Change the search path for the locally installed sidecar binary, hopefully to the correct location.

Overview of the deactivate function:
====================

The first part of this PR exports a new deactivate function from the Codestory extension, alongside the existing activate function, which VS Code will call on extensions when closing down.

I created this change a week or so ago, but subsequently created a PR to revert it again as I was worried that I'd broken Aide. Lots of people were reporting issues with the sidecar not working, and I noticed that VS code processes didn't work the way I thought they did, so I worried maybe I'd broken it. However, it turns out my changes weren't the issue after all.

The deactivate function terminates the webserver. This ensures the webserver isn't left running as a zombie in the background after exiting Aide. To make this work I've promisified the existing process termination code, because callbacks won't work if an application is about to exit.

Some notes on the way processes interact:
================================

Regarding VS code processes:
1. It appears the VS Code extension host process restarts whenever you open a folder, which in turn results in all extensions being deactivated and then re-activated. So the sidecar binary is killed and then restarted every time someone opens a folder. This appears to be a feature of VS Code, and affects all extensions. Given the webserver seems to start up pretty quickly this shouldn't be an issue.

2. When the extension host process restarts it seems like break points in the "activate" function aren't hit unless you await a setTimeout call to sleep for a bit. My assumption is that this is because it takes a while for the debugger to re-attach to the newly created extension host process.

Also, info regarding Linux/Mac processes generally:

- I've learned that by default child processes automatically reparented if their parent dies (to systemd in modern Linux systems), there is no automatic cleanup of child processes when a parent is terminated. In Linux parents can call blocking `wait` on children, which waits for them to complete, or they can call non-blocking `wait` repeatedly in a loop waiting for them to complete, or they can manually terminate children when they themselves receive a termination signal.

(for a more completist overview, note that things are a bit different when the parent process is the child of a shell and the shell is terminated, e.g. when running a vanilla node app via the shell). But

Overview of changes to logic related to downloading binary and finding installed sidecar binary
========================================================================

The sidecar binary is always bundled with Aide, so it shouldn't be necessary to check what version it is and optionally download a new version from GCP. I've deleted all of this code.

Whilst removing this code I noticed that it is searching for the binary in a path inside `vscode.env.appRoot`, which I suspect is incorrect, and hence actually the IDE was always downloading a copy from GCP when first opened after install regardless. I've changed this code to look for a path inside `vscode.extensions.getExtension('codestory-ghost.codestoryai')`, but this is as yet untested.
