### PR TITLE
Disambiguate non-blocking terminal commands

### DIFF
--- a/extensions/codestory/src/server/requestHandler.ts
+++ b/extensions/codestory/src/server/requestHandler.ts
@@ -233,7 +233,7 @@ export function handleRequest(
 				const body = await readRequestBody(req);
 				const request: SidecarExecuteTerminalCommandRequest = JSON.parse(body);
 				// always pass in the workspace over here not the process.cwd which would be wrong
-				const response = await executeTerminalCommand(request.command, workspace.rootPath ?? '');
+				const response = await executeTerminalCommand(request.command, workspace.rootPath ?? '', request.wait_for_exit);
 				res.writeHead(200, { 'Content-Type': 'application/json' });
 				res.end(JSON.stringify({ output: response }));
 			} else {

--- a/extensions/codestory/src/server/types.ts
+++ b/extensions/codestory/src/server/types.ts
@@ -793,6 +793,7 @@ export type SidecarListFilesOutput = {
 
 export type SidecarExecuteTerminalCommandRequest = {
 	command: string;
+	wait_for_exit: boolean;
 };
 
 interface OpenFileRequest {


### PR DESCRIPTION
Currently, we have an arbitrary heuristic on the editor side to wait for 10 seconds for a terminal command to complete, and proceed to the next iteration. But I keep running into cases within the editor where this blows up. This PR makes the LLM share an additional `wait_for_exit` param for the `execute_command` tool call - which, if true, the editor returns only after the command run is complete. And if false, the editor returns instantly after running the command.

Sidecar PR: https://github.com/codestoryai/sidecar/pull/1778