### PR TITLE
Handle sidecar panics gracefully on the editor

### DIFF
--- a/extensions/codestory/src/server/types.ts
+++ b/extensions/codestory/src/server/types.ts
@@ -382,6 +382,11 @@ interface UIEvent {
 	ChatEvent: ChatMessageEvent;
 	ExchangeEvent: ExchangeMessageEvent;
 	PlanEvent: PlanMessageEvent;
+	Error: ErrorEvent;
+}
+
+interface ErrorEvent {
+	message: string;
 }
 
 interface TerminalCommandEvent {


### PR DESCRIPTION
Right now, when sidecar panics (for whatever reason), we don't get any information on the editor side and users are left indefinitely waiting for updates. This PR handles panic events sent from the sidecar during execution, as well as panics that might occur before a single event has been fired by the sidecar.

Corresponding PR on the editor side: https://github.com/codestoryai/sidecar/pull/1781