### PR TITLE
[agent_farm] update requesthandler in codestory extension to allow overwriting the content of the full file (Run ID: codestoryai_aide_issue_1261_de280aa9)

### DIFF
--- a/extensions/codestory/src/server/applyEdits.ts
+++ b/extensions/codestory/src/server/applyEdits.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { SidecarApplyEditsRequest, SidecarApplyEditsResponse } from './types';
+import { SidecarApplyEditsRequest, SidecarApplyEditsResponse, SidecarOverwriteFileRequest } from './types';
 import * as vscode from 'vscode';
 
 /**

--- a/extensions/codestory/src/server/applyEdits.ts
+++ b/extensions/codestory/src/server/applyEdits.ts
@@ -125,6 +125,33 @@ export async function applyEdits(
 	};
 }
 
+/**
+ * Overwrites the entire content of a file
+ */
+export async function overwriteFile(
+    request: SidecarOverwriteFileRequest,
+): Promise<{fs_file_path: string; success: boolean}> {
+    const filePath = request.fs_file_path;
+    const fileUri = vscode.Uri.file(filePath);
+
+    const workspaceEdit = new vscode.WorkspaceEdit();
+    // Create a range that covers the entire file
+    const document = await vscode.workspace.openTextDocument(fileUri);
+    const fullRange = new vscode.Range(
+        new vscode.Position(0, 0),
+        new vscode.Position(document.lineCount, 0)
+    );
+    
+    workspaceEdit.replace(fileUri, fullRange, request.content);
+    await vscode.workspace.applyEdit(workspaceEdit);
+    await vscode.workspace.save(fileUri);
+
+    return {
+        fs_file_path: filePath,
+        success: true
+    };
+}
+
 export interface ITask<T> {
 	(): T;
 }

--- a/extensions/codestory/src/server/applyEdits.ts
+++ b/extensions/codestory/src/server/applyEdits.ts
@@ -135,14 +135,13 @@ export async function overwriteFile(
     const fileUri = vscode.Uri.file(filePath);
 
     const workspaceEdit = new vscode.WorkspaceEdit();
-    // Create a range that covers the entire file
     const document = await vscode.workspace.openTextDocument(fileUri);
     const fullRange = new vscode.Range(
         new vscode.Position(0, 0),
-        new vscode.Position(document.lineCount, 0)
+        document.lineAt(document.lineCount - 1).range.end
     );
     
-    workspaceEdit.replace(fileUri, fullRange, request.content);
+    workspaceEdit.replace(fileUri, fullRange, request.updated_content);
     await vscode.workspace.applyEdit(workspaceEdit);
     await vscode.workspace.save(fileUri);
 

--- a/extensions/codestory/src/server/requestHandler.ts
+++ b/extensions/codestory/src/server/requestHandler.ts
@@ -3,8 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import * as http from 'http';
-import { SidecarApplyEditsRequest, LSPDiagnostics, SidecarGoToDefinitionRequest, SidecarGoToImplementationRequest, SidecarGoToReferencesRequest, SidecarOpenFileToolRequest, LSPQuickFixInvocationRequest, SidecarQuickFixRequest, SidecarSymbolSearchRequest, SidecarInlayHintsRequest, SidecarGetOutlineNodesRequest, SidecarOutlineNodesWithContentRequest, EditedCodeStreamingRequest, SidecarRecentEditsRetrieverRequest, SidecarRecentEditsRetrieverResponse, SidecarCreateFileRequest, LSPFileDiagnostics, SidecarGetPreviousWordRangeRequest, SidecarDiagnosticsResponse, SidecarCreateNewExchangeRequest, SidecarUndoPlanStep, SidecarExecuteTerminalCommandRequest, SidecarListFilesEndpoint } from './types';
+import { SidecarApplyEditsRequest, LSPDiagnostics, SidecarGoToDefinitionRequest, SidecarGoToImplementationRequest, SidecarGoToReferencesRequest, SidecarOpenFileToolRequest, LSPQuickFixInvocationRequest, SidecarQuickFixRequest, SidecarSymbolSearchRequest, SidecarInlayHintsRequest, SidecarGetOutlineNodesRequest, SidecarOutlineNodesWithContentRequest, EditedCodeStreamingRequest, SidecarRecentEditsRetrieverRequest, SidecarRecentEditsRetrieverResponse, SidecarCreateFileRequest, LSPFileDiagnostics, SidecarGetPreviousWordRangeRequest, SidecarDiagnosticsResponse, SidecarCreateNewExchangeRequest, SidecarUndoPlanStep, SidecarExecuteTerminalCommandRequest, SidecarListFilesEndpoint, SidecarOverwriteFileRequest } from './types';
 import { Position, Range, workspace } from 'vscode';
+import { applyEdits, applyEditsDirectly, overwriteFile } from './applyEdits';
 import { getDiagnosticsFromEditor, getEnrichedDiagnostics, getFileDiagnosticsFromEditor, getFullWorkspaceDiagnostics, getHoverInformation } from './diagnostics';
 import { openFileEditor } from './openFile';
 import { goToDefinition } from './goToDefinition';
@@ -236,6 +237,12 @@ export function handleRequest(
 				console.log('hitting devtool_screenshot');
 				const response = await getBrowserScreenshot();
 				console.log('screenshot: ', response);
+				res.writeHead(200, { 'Content-Type': 'application/json' });
+				res.end(JSON.stringify(response));
+			} else if (req.method === 'POST' && req.url === '/overwrite_file') {
+				const body = await readRequestBody(req);
+				const request: SidecarOverwriteFileRequest = JSON.parse(body);
+				const response = await overwriteFile(request);
 				res.writeHead(200, { 'Content-Type': 'application/json' });
 				res.end(JSON.stringify(response));
 			} else {

--- a/extensions/codestory/src/server/requestHandler.ts
+++ b/extensions/codestory/src/server/requestHandler.ts
@@ -5,7 +5,7 @@
 import * as http from 'http';
 import { SidecarApplyEditsRequest, LSPDiagnostics, SidecarGoToDefinitionRequest, SidecarGoToImplementationRequest, SidecarGoToReferencesRequest, SidecarOpenFileToolRequest, LSPQuickFixInvocationRequest, SidecarQuickFixRequest, SidecarSymbolSearchRequest, SidecarInlayHintsRequest, SidecarGetOutlineNodesRequest, SidecarOutlineNodesWithContentRequest, EditedCodeStreamingRequest, SidecarRecentEditsRetrieverRequest, SidecarRecentEditsRetrieverResponse, SidecarCreateFileRequest, LSPFileDiagnostics, SidecarGetPreviousWordRangeRequest, SidecarDiagnosticsResponse, SidecarCreateNewExchangeRequest, SidecarUndoPlanStep, SidecarExecuteTerminalCommandRequest, SidecarListFilesEndpoint, SidecarOverwriteFileRequest } from './types';
 import { Position, Range, workspace } from 'vscode';
-import { applyEdits, applyEditsDirectly, overwriteFile } from './applyEdits';
+import { overwriteFile } from './applyEdits';
 import { getDiagnosticsFromEditor, getEnrichedDiagnostics, getFileDiagnosticsFromEditor, getFullWorkspaceDiagnostics, getHoverInformation } from './diagnostics';
 import { openFileEditor } from './openFile';
 import { goToDefinition } from './goToDefinition';

--- a/extensions/codestory/src/server/types.ts
+++ b/extensions/codestory/src/server/types.ts
@@ -1181,7 +1181,7 @@ export type SidecarRecentEditsRetrieverRequest = {
 
 export type SidecarOverwriteFileRequest = {
     fs_file_path: string;
-    content: string;
+    updated_content: string;
 };
 
 export type SidecarApplyEditsRequest = {

--- a/extensions/codestory/src/server/types.ts
+++ b/extensions/codestory/src/server/types.ts
@@ -1179,6 +1179,11 @@ export type SidecarRecentEditsRetrieverRequest = {
 	diff_file_content: SidecarRecentEditsFilePreviousContent[];
 };
 
+export type SidecarOverwriteFileRequest = {
+    fs_file_path: string;
+    content: string;
+};
+
 export type SidecarApplyEditsRequest = {
 	fs_file_path: string;
 	edited_content: string;


### PR DESCRIPTION
agent_instance: codestoryai_aide_issue_1261_de280aa9 Tries to fix: #1261

**Enhancement:** Added new endpoint to allow overwriting entire file contents in the codestory extension.

- **Added:** New `SidecarOverwriteFileRequest` type and `/overwrite_file` endpoint
- **Implemented:** File overwrite functionality using VSCode's workspace API for safe file handling
- 🔍 Team review needed, particularly for error handling and workspace synchronization aspects.