### PR TITLE
Connection error with sidecar (Run ID: codestoryai_aide_issue_1280_6f810a04)

### DIFF
--- a/src/vs/workbench/contrib/aideAgent/browser/aideAgentInputPart.ts
+++ b/src/vs/workbench/contrib/aideAgent/browser/aideAgentInputPart.ts
@@ -745,6 +745,15 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		element.appendChild(textSpan);
 		element.appendChild(iconSpan);
 
+		// Make the status message more prominent when there's an error
+		if (runningStatus !== SidecarRunningStatus.Connected) {
+			element.classList.add('error-status');
+			textSpan.style.fontWeight = 'bold';
+		} else {
+			element.classList.remove('error-status');
+			textSpan.style.fontWeight = 'normal';
+		}
+
 		this._register(this.sidecarService.onDidChangeStatus(({ version, runningStatus, downloadStatus }) => {
 			const { text, color, updateAvailable, hover } = this.getSidecarStatus(runningStatus, downloadStatus, version);
 			textSpan.textContent = text;
@@ -756,8 +765,22 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 
 			if (runningStatus !== SidecarRunningStatus.Connected) {
 				this.inputEditor.updateOptions({ readOnly: true });
+				element.classList.add('error-status');
+				textSpan.style.fontWeight = 'bold';
 			} else {
 				this.inputEditor.updateOptions({ readOnly: false });
+				element.classList.remove('error-status');
+				textSpan.style.fontWeight = 'normal';
+			}
+		}));
+
+		// Add a focus event listener to show a notification when the sidecar is not connected
+		this._register(this.inputEditor.onDidFocusEditorText(() => {
+			if (this.sidecarService.runningStatus !== SidecarRunningStatus.Connected) {
+				this.notificationService.info(
+					localize('chat.sidecarNotConnected', 
+					"The sidecar is not connected. Please wait for it to connect or click on the status indicator to restart it.")
+				);
 			}
 		}));
 	}


### PR DESCRIPTION
agent_instance: codestoryai_aide_issue_1280_6f810a04 Tries to fix: #1280

# 🔄 **Fix:** Improved Sidecar Connection Error Handling

- **Added:** Enhanced error feedback with visual styling for sidecar status message
- **Added:** User notification when attempting to use chat input while sidecar is disconnected
- **Improved:** Properly disable/enable editor based on sidecar connection state

This update provides clearer user feedback when the sidecar is not connected, guiding users to either wait for connection or restart the sidecar when needed. Please review these changes with focus on the user experience improvements around connection error states.