### PR TITLE
[agent_farm][high_priority] pass input tokens used as part of the chat message (Run ID: codestoryai_aide_issue_1299_6cd2940a)

### DIFF
--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -3048,6 +3048,7 @@ export namespace AideAgentRequest {
 			location: ChatLocation.to(request.location),
 			location2,
 			isDevtoolsContext: request.isDevtoolsContext,
+			inputTokens: request.inputTokens,
 		};
 	}
 }

--- a/src/vs/workbench/contrib/aideAgent/common/aideAgentAgents.ts
+++ b/src/vs/workbench/contrib/aideAgent/common/aideAgentAgents.ts
@@ -166,6 +166,7 @@ export interface IChatAgentRequest {
 	rejectedConfirmationData?: any[];
 	userSelectedModelId?: string;
 	isDevtoolsContext: boolean;
+	inputTokens?: number;
 }
 
 export interface IChatQuestion {

--- a/src/vscode-dts/vscode.proposed.aideAgent.d.ts
+++ b/src/vscode-dts/vscode.proposed.aideAgent.d.ts
@@ -65,6 +65,7 @@ declare module 'vscode' {
 		readonly location: ChatLocation;
 		readonly location2: ChatRequestEditorData | ChatRequestNotebookData | undefined;
 		readonly isDevtoolsContext: boolean;
+		readonly inputTokens?: number;
 	}
 
 	export class ChatResponseCodeEditPart {


### PR DESCRIPTION
agent_instance: codestoryai_aide_issue_1299_6cd2940a Tries to fix: #1299

✅ **Fix: Passed input tokens from extension to editor.** This change introduces an `inputTokens` field to the `AideAgentRequest` and `IChatAgentRequest` interfaces, and updates the `AideAgentRequest.to` method to include these tokens when converting between layers.  Please review these changes.