### PR TITLE
LLM (Run ID: codestoryai_aide_issue_1321_ae73004c)

### DIFF
--- a/extensions/codestory/src/completions/providers/aideAgentProvider.ts
+++ b/extensions/codestory/src/completions/providers/aideAgentProvider.ts
@@ -611,7 +611,7 @@ export class AideAgentSessionProvider implements vscode.AideSessionParticipant {
 
 					const stream = this.responseStreamCollection.latestResponseStream ?? await this.createNewResponseStream(event.request_id);
 					if (stream) {
-						if (event.event.Error.message.toLowerCase().endsWith('wrong tool output')) {
+						if (event.event.Error.message.toLowerCase().includes('wrong tool output') || event.event.Error.message.toLowerCase().includes('format')) {
 							stream.stream.toolTypeError({
 								message: `The LLM that you're using right now returned a response that does not adhere to the format our framework expects, and thus this request has failed. If you keep seeing this error, this is likely because the LLM is unable to follow our system instructions and it is recommended to switch over to one of our recommended models instead.`
 							});
@@ -736,9 +736,15 @@ export class AideAgentSessionProvider implements vscode.AideSessionParticipant {
 							responseStream.stream.toolTypeError({
 								message: `Usage limit exceeded. Please upgrade.`
 							});
-						} else {
+						} else if (error_string.includes('wrong tool output') || error_string.includes('format')) {
 							responseStream.stream.toolTypeError({
 								message: `The LLM that you're using right now returned a response that does not adhere to the format our framework expects, and thus this request has failed. If you keep seeing this error, this is likely because the LLM is unable to follow our system instructions and it is recommended to switch over to one of our recommended models instead.`
+							});
+							responseStream.stream.stage({ message: 'Error' });
+							errorCallback?.();
+						} else {
+							responseStream.stream.toolTypeError({
+								message: `An error occurred: ${error_string}. Please try again.`
 							});
 							responseStream.stream.stage({ message: 'Error' });
 							errorCallback?.();


### PR DESCRIPTION
agent_instance: codestoryai_aide_issue_1321_ae73004c Tries to fix: #1321

🔧 **Bug Fix:** Improved error message specificity for LLM format-related issues

- **Modified:** Error handling in `aideAgentProvider.ts` to only show the format-specific error message when the error actually includes 'wrong tool output' or 'format' in the message
- **Improved:** User experience by providing more accurate feedback about what went wrong instead of showing the generic LLM format error message for all types of errors

This change ensures that the format error message is only shown when it's actually relevant to the error that occurred, which should significantly reduce the frequency of this error message appearing inappropriately. 👀