### PR TITLE
[CRITICAL] Account page shows me suddenly as 'free' (payed few days ago) (Run ID: codestoryai_aide_issue_1323_e963a3c2)

### DIFF
--- a/fail.txt
+++ b/fail.txt
@@ -1,0 +1,2 @@
+No changes were made by the agent.
+run_id: codestoryai_aide_issue_1323_e963a3c2


### PR DESCRIPTION
agent_instance: codestoryai_aide_issue_1323_e963a3c2 Tries to fix: #1323

I'll analyze the MCTS data and craft an appropriate PR message.

🔍 **Investigation Complete:** Identified that account page showing 'free' despite payment is a server-side issue, not a client-side bug

- **Analysis:** Examined the extension's authentication, subscription, and error handling code
- **Findings:** The error messages are generated by the server API and simply displayed by the client
- **Recommendation:** The issue needs to be addressed by the backend subscription management system